### PR TITLE
Fix plaintext typo

### DIFF
--- a/03-likelihoods.Rmd
+++ b/03-likelihoods.Rmd
@@ -287,7 +287,7 @@ Hopefully, researchers become more inclined to submit nonsignificant findings fo
 
 So far we have computed likelihoods for binomial probabilities, but likelihoods can be computed for any statistical model [@glover_likelihood_2004; @pawitan_all_2001]. For example, we can compute the relative likelihood of observing a *t*-value under the null and an alternative hypothesis (Figure \@ref(fig:like9)). Of course, the observed data is most likely if we assume the observed effect equals the true effect, but examining the likelihood reveals that there are many alternative hypotheses that are relatively more likely than the null hypothesis. This also holds when observing nonsignificant results, which can be more likely under an alternative hypothesis of interest, than under the null hypothesis. This is a reason why it is incorrect to say that there is no effect when *p* > $\alpha$ (see [*p*-value misconception 1](#misconception1)). 
 
-(ref:like9lab) Likelihood ratio for observed *t*-value under H0 and H1.
+(ref:like9lab) Likelihood ratio for observed *t*-value under $H_0$ and $H_1$.
 
 ```{r, like9,  echo = FALSE, fig.cap="(ref:like9lab)"}
 


### PR DESCRIPTION
It fixes forgotted math mode for `H0` and `H1`.