### PR TITLE
Fix punctuation

### DIFF
--- a/01-pvalue.Rmd
+++ b/01-pvalue.Rmd
@@ -164,9 +164,9 @@ In the simulation, we generate n = 71 normally distributed IQ scores with means 
 ```{r, pdistr1, cache = TRUE, echo=FALSE, fig.cap = '(ref:pdist1lab)'}
 
 #Set number of simulations
-nSims <- 100000 #number of simulated experiments
-p <-numeric(nSims) #set up empty variable to store all simulated *p*-values
-bars<-20
+nSims <- 100000 # number of simulated experiments
+p <- numeric(nSims) # set up empty variable to store all simulated *p*-values
+bars <- 20
 
 for (i in 1:nSims) { # for each simulated experiment
   x <- rnorm(n = 71, mean = 100, sd = 15) # Simulate data
@@ -179,7 +179,7 @@ par(bg = backgroundcolor)
 op <- par(mar = c(5,7,4,4)) #change white-space around graph
 hist(p, breaks=bars, xlab="P-values", ylab="number of p-values\n", axes=FALSE,
      main=paste("P-value Distribution with 50% power"),
-     col="grey", xlim=c(0,1),  ylim=c(0, nSims))
+     col="grey", xlim=c(0,1), ylim=c(0, nSims))
 axis(side=1, at=seq(0,1, 0.1), labels=seq(0,1,0.1))
 axis(side=2, at=seq(0,nSims, nSims/4), labels=seq(0,nSims, nSims/4), las=2)
 abline(h=nSims/bars, col = "red", lty=3)
@@ -238,7 +238,7 @@ op <- par(mar = c(5,7,4,4)) #change white-space around graph
 par(bg = backgroundcolor)
 hist(p, breaks=bars, xlab="P-values", ylab="number of p-values\n", axes=FALSE,
      main=paste("P-value distribution when the null hypothesis is true"),
-     col="grey", xlim=c(0,1),  ylim=c(0, nSims))
+     col="grey", xlim=c(0,1), ylim=c(0, nSims))
 axis(side=1, at=seq(0,1, 0.1), labels=seq(0,1,0.1))
 axis(side=2, at=seq(0,nSims, nSims/4), labels=seq(0,nSims, nSims/4), las=2)
 abline(h=nSims/bars, col = "red", lty=3)
@@ -699,8 +699,8 @@ power <- round((sum(p < 0.05) / nsims), 2) # power
 # Plot figure
 hist(p,
   breaks = bars, xlab = "P-values", ylab = "number of p-values\n", 
-  axes = FALSE,  main = paste("P-value Distribution with", 
-                              round(power * 100, digits = 1), "% Power"),
+  axes = FALSE, main = paste("P-value Distribution with", 
+                             round(power * 100, digits = 1), "% Power"),
   col = "grey", xlim = c(0, 1), ylim = c(0, nsims))
 axis(side = 1, at = seq(0, 1, 0.1), labels = seq(0, 1, 0.1))
 axis(side = 2, at = seq(0, nsims, nsims / 4), 

--- a/06-effectsize.Rmd
+++ b/06-effectsize.Rmd
@@ -9,7 +9,7 @@ library(patchwork)
 
 # Effect Sizes {#effectsize}
 
-Effect sizes are an important statistical outcome in most empirical studies. Researchers want to know whether an intervention or experimental manipulation has an effect greater than zero, or (when it is obvious an effect exists) how big the effect is. Researchers are often reminded to report effect sizes, because they are useful for three reasons. First, they allow researchers to present the magnitude of the reported effects, which allow researchers to reflect on the **practical significance** of the  effects they report, in addition to the *statistical* significance. Second, effect sizes allow researchers to draw meta-analytic conclusions by comparing standardized effect sizes across studies. Third, effect sizes from previous studies can be used when planning a new study in an a-priori power analysis.
+Effect sizes are an important statistical outcome in most empirical studies. Researchers want to know whether an intervention or experimental manipulation has an effect greater than zero, or (when it is obvious an effect exists) how big the effect is. Researchers are often reminded to report effect sizes, because they are useful for three reasons. First, they allow researchers to present the magnitude of the reported effects, which allow researchers to reflect on the **practical significance** of the effects they report, in addition to the *statistical* significance. Second, effect sizes allow researchers to draw meta-analytic conclusions by comparing standardized effect sizes across studies. Third, effect sizes from previous studies can be used when planning a new study in an a-priori power analysis.
 
 A measure of effect size is a quantitative description of the strength of a phenomenon. It is expressed as a number on a scale. For **unstandardized effect sizes**, the effect size is expressed on the scale that the measure was collected on. This is useful whenever people are able to intuitively interpret differences on a measurement scale. For example, children grow on average 6 centimeters a year between the age of 2 and puberty. We can interpret 6 centimeters a year as an effect size, and many people in the world have an intuitive understanding of how large 6 cm is. Where a *p*-value is used to make a claim about whether there is an effect, or whether we might just be looking at random variation in the data, an effect size is used to answer the question how large the effect is. This makes an effect size estimate an important complement to *p*-values in most studies. A *p*-value tells us we can claim children grow as they age; effect sizes tell us what size clothes we can expect children to wear when they are a certain age, and how long it will take before their new clothes are too small. 
 
@@ -203,7 +203,7 @@ An $\eta^2$ of .13 means that 13% of the total variance can be accounted for by 
 
 $$\eta_{p}^{2} = \frac{\text{SS}_{\text{effect}}}{\text{SS}_{\text{effect}} + \text{SS}_{\text{error}}}$$
 
-For designs with fixed factors (manipulated factors, or factors that exhaust all levels of the independent variable, such as alive vs. dead), but not for designs with measured factors or covariates, partial eta squared can be computed from the *F*-value and its degrees of freedom [@cohen_statistical_1988]:   
+For designs with fixed factors (manipulated factors, or factors that exhaust all levels of the independent variable, such as alive vs. dead), but not for designs with measured factors or covariates, partial eta squared can be computed from the *F*-value and its degrees of freedom [@cohen_statistical_1988]:
 
 $$\eta_{p}^{2} = \frac{F \times \text{df}_{\text{effect}}}{{F \times \text{df}}_{\text{effect}} + \text{df}_{\text{error}}}$$
 
@@ -216,7 +216,7 @@ Eta squared can be transformed into Cohen’s *d*:
 
 ## Correcting for Bias
 
-Population effect sizes are almost always estimated on the basis of samples, and as a measure of the population effect size estimate based on sample averages, Cohen’s *d* slightly overestimates the true population effect. When Cohen’s *d* refers to the population, the Greek letter δ is typically used. Therefore, corrections for bias are used (even though these corrections do not always lead to a completely unbiased effect size estimate). In the *d* family of effect sizes, the correction for bias in the population effect size estimate of Cohen’s *d* is known as Hedges’ *g* (although different people use different names – $d_{unbiased}$ is also used). This correction for bias is only noticeable in small sample sizes, but since we often use software to calculate effect sizes anyway, it makes sense to always report Hedge’s *g* instead of Cohen’s *d*  [@thompson_effect_2007].
+Population effect sizes are almost always estimated on the basis of samples, and as a measure of the population effect size estimate based on sample averages, Cohen’s *d* slightly overestimates the true population effect. When Cohen’s *d* refers to the population, the Greek letter δ is typically used. Therefore, corrections for bias are used (even though these corrections do not always lead to a completely unbiased effect size estimate). In the *d* family of effect sizes, the correction for bias in the population effect size estimate of Cohen’s *d* is known as Hedges’ *g* (although different people use different names – $d_{unbiased}$ is also used). This correction for bias is only noticeable in small sample sizes, but since we often use software to calculate effect sizes anyway, it makes sense to always report Hedge’s *g* instead of Cohen’s *d* [@thompson_effect_2007].
 
 As with Cohen’s *d*, $\eta^2$ is a biased estimate of the true effect size in the population. Two less biased effect size estimates have been proposed, epsilon squared $\varepsilon^{2}$ and omega squared $\omega^{2}$. For all practical purposes, these two effect sizes correct for bias equally well [@okada_is_2013; @albers_when_2018], and should be preferred above $\eta^2$. Partial epsilon squared ($\varepsilon_{p}^{2}$) and partial omega squared ($\omega_{p}^{2}$) can be calculated based on the *F*-value and degrees of freedom.
 
@@ -270,10 +270,10 @@ df <- data.frame(
 p1 <- ggplot(data=df, aes(x=A, y=Y, group=B, shape=B)) +
     geom_line(size = 2) +
     geom_point(size = 4, fill = "white") +
-  scale_shape_manual(values=c(22,21)) +
+  scale_shape_manual(values = c(22, 21)) +
   ggtitle("disordinal interaction") +
   theme_bw() + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 df <- data.frame(
@@ -285,10 +285,10 @@ df <- data.frame(
 p2 <- ggplot(data=df, aes(x=A, y=Y, group=B, shape=B)) +
     geom_line(size = 2) +
     geom_point(size = 4, fill = "white") +
-  scale_shape_manual(values=c(22,21)) +
+  scale_shape_manual(values = c(22, 21)) +
   ggtitle("ordinal interaction") +
   theme_bw() + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 # Use patchwork to combine and plot only 1 legend without title.
@@ -421,9 +421,9 @@ D) *d* = 0.75
 **Q8**: In an old paper you find a statistical result from a 2x3 between subjects ANOVA reported as *F*(2, 122) = 4.13, *p* < 0.05, without a reported effect size. Using the online MOTE app <https://doomlab.shinyapps.io/mote/> (choose Eta – F from the Variance Overlap dropdown menu) or the MOTE R function eta.F, what is the effect size in partial eta-squared?
 
 A) $\eta_p^2$ = 0.063
-B) $\eta_p^2$  = 0.996
-C) $\eta_p^2$  = 0.032
-D) $\eta_p^2$  = 0.049
+B) $\eta_p^2$ = 0.996
+C) $\eta_p^2$ = 0.032
+D) $\eta_p^2$ = 0.049
 
 **Q9**: You realize that computing omega-squared corrects for some of the bias in eta-squared. For the old paper with *F*(2, 122) = 4.13, *p* < 0.05, and using the online MOTE app <https://doomlab.shinyapps.io/mote/> (choose Omega – F from the Variance Overlap dropdown menu) or the MOTE R function `omega.F`, what is the effect size in partial omega-squared? HINT: The total sample size is the df error + k, where k is the number of groups (which is 6 for the 2x3 ANOVA). 
 
@@ -432,21 +432,21 @@ B) $\eta_p^2$ = 0.749
 C) $\eta_p^2$ = 0.032
 D) $\eta_p^2$ = 0.024
 
-**Q10**: Several times in this chapter the effect size Cohen’s *d* was converted to *r*, or vice versa. We can use the `effectsize`  R package (that can also be used to compute effect sizes when you analyze your data in R) to convert the median *r* = 0.21 observed in Richard and colleagues’ meta-meta-analysis to *d*: `effectsize::r_to_d(0.21)` which (assuming equal sample sizes per condition) yields *d* = 0.43 (the conversion assumes equal sample sizes in each group). Which Cohen’s *d* corresponds to a *r* = 0.1?
+**Q10**: Several times in this chapter the effect size Cohen’s *d* was converted to *r*, or vice versa. We can use the `effectsize` R package (that can also be used to compute effect sizes when you analyze your data in R) to convert the median *r* = 0.21 observed in Richard and colleagues’ meta-meta-analysis to *d*: `effectsize::r_to_d(0.21)` which (assuming equal sample sizes per condition) yields *d* = 0.43 (the conversion assumes equal sample sizes in each group). Which Cohen’s *d* corresponds to a *r* = 0.1?
 
 A) *d* = 0.05
 B) *d* = 0.10
 C) *d* = 0.20
 D) *d* = 0.30
 
-**Q11**: It can be useful to convert effect sizes to *r* when performing a meta-analysis where not all effect sizes that are included are based on mean differences. Using the d_to_r function in the `effectsize` package, what does a *d* = 0.8 correspond to (again assuming equal sample sizes per condition)? 
+**Q11**: It can be useful to convert effect sizes to *r* when performing a meta-analysis where not all effect sizes that are included are based on mean differences. Using the `d_to_r()` function in the `effectsize` package, what does a *d* = 0.8 correspond to (again assuming equal sample sizes per condition)? 
 
 A) *r* = 0.30
 B) *r* = 0.37
 C) *r* = 0.50
 D) *r* = 0.57
 
-**Q12**: From questions 10 and 11 you might have noticed something peculiar. The benchmarks typically used for ‘small’, ‘medium’, and ‘large’ effects for Cohen’s d are *d* = 0.2, *d* = 0.5, and *d* = 0.8, and for a correlation are *r* = 0.1, *r* = 0.3, and *r* = 0.5. Using the d_to_r function in the `effectsize` package, check to see whether the benchmark for a ‘large’ effect size correspond between *d* and *r*.
+**Q12**: From questions 10 and 11 you might have noticed something peculiar. The benchmarks typically used for ‘small’, ‘medium’, and ‘large’ effects for Cohen’s d are *d* = 0.2, *d* = 0.5, and *d* = 0.8, and for a correlation are *r* = 0.1, *r* = 0.3, and *r* = 0.5. Using the `d_to_r()` function in the `effectsize` package, check to see whether the benchmark for a ‘large’ effect size correspond between *d* and *r*.
 
 As @mcgrath_when_2006 write: “Many users of Cohen’s (1988) benchmarks seem unaware that those for the correlation coefficient and d are not strictly equivalent, because Cohen’s generally cited benchmarks for the correlation were intended for the infrequently used biserial correlation rather than for the point biserial.” 
 

--- a/07-CI.Rmd
+++ b/07-CI.Rmd
@@ -33,7 +33,7 @@ where *N* is the size of the population, and *n* is the size of the sample. When
 
 ## What is a Confidence Interval?
 
-Confidence intervals are a statement about the percentage of confidence intervals that contain the true parameter value. This behavior of confidence intervals is nicely visualized on this website by Kristoffer Magnusson: <http://rpsychologist.com/d3/CI/>.  In Figure \@ref(fig:cisim) We see blue dots that represent means from a sample, and that fall around a red vertical line, which represents the true value of the parameter in the population. Due to variation in the sample, the estimates do not all fall on the red line. The horizontal lines around the blue dots are the confidence intervals. By default, the visualization shows 95% confidence intervals. Most of the lines are black (which means the confidence interval overlaps with the orange dashed line indicating the true population value), but some are red (indicating they do not capture the true population value). In the long run, 95% of the horizontal bars will be black, and 5% will be red. 
+Confidence intervals are a statement about the percentage of confidence intervals that contain the true parameter value. This behavior of confidence intervals is nicely visualized on this website by Kristoffer Magnusson: <http://rpsychologist.com/d3/CI/>. In Figure \@ref(fig:cisim) We see blue dots that represent means from a sample, and that fall around a red vertical line, which represents the true value of the parameter in the population. Due to variation in the sample, the estimates do not all fall on the red line. The horizontal lines around the blue dots are the confidence intervals. By default, the visualization shows 95% confidence intervals. Most of the lines are black (which means the confidence interval overlaps with the orange dashed line indicating the true population value), but some are red (indicating they do not capture the true population value). In the long run, 95% of the horizontal bars will be black, and 5% will be red. 
 
 
 
@@ -73,8 +73,8 @@ metadata <- data.frame(yi = numeric(0), vi = numeric(0))
 
 for (i in 1:nSims) { # for each simulated study
   n <- sample(30:80, 1)
-  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce  simulated participants
-  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce  simulated participants
+  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce simulated participants
+  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce simulated participants
   metadata[i,1] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$yi
   metadata[i,2] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$vi
 }
@@ -184,9 +184,9 @@ ggplot(as.data.frame(x), aes(x)) + # plot data
   geom_rect(aes(xmin = cil, xmax = ciu, ymin = 0, ymax = Inf),
             fill = "#E69F00") + # draw orange CI area
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..),
-                 bins = 20) +  xlab("Score") +  ylab("frequency") +
+                 bins = 20) + xlab("Score") + ylab("frequency") +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(),
         panel.grid.minor.x = element_blank()) +
@@ -210,7 +210,7 @@ When we rewrite the formula used for the confidence interval to $\sigma/\sqrt(1/
 
 ## Capture Percentages
 
-It can be difficult to understand why a 95% confidence interval does not provide us with the interval where 95% of future means will fall. The percentage of means that falls within a single confidence interval is called the **capture percentage**. A capture percentage is not something we would ever use to make inferences about data, but it is useful to learn about capture percentages to prevent misinterpreting confidence intervals. In Figure \@ref(fig:metaci) we see two randomly simulated studies with the same sample size from the same population. The true effect size in both studies is 0, and we see that the 95% confidence intervals for both studies contain the true population value of 0. However, the two confidence intervals cover quite different ranges of effect sizes, with the confidence interval in Study 1 ranging from -0.07 to 0.48, and the confidence interval in Study 2 ranging from -0.50 to 0.06. It cannot be true that in the future, we should expect 95% of the effect sizes  to fall between -0.07 to 0.48 **and** 95% of the effect sizes to fall between -0.50 to 0.06. 
+It can be difficult to understand why a 95% confidence interval does not provide us with the interval where 95% of future means will fall. The percentage of means that falls within a single confidence interval is called the **capture percentage**. A capture percentage is not something we would ever use to make inferences about data, but it is useful to learn about capture percentages to prevent misinterpreting confidence intervals. In Figure \@ref(fig:metaci) we see two randomly simulated studies with the same sample size from the same population. The true effect size in both studies is 0, and we see that the 95% confidence intervals for both studies contain the true population value of 0. However, the two confidence intervals cover quite different ranges of effect sizes, with the confidence interval in Study 1 ranging from -0.07 to 0.48, and the confidence interval in Study 2 ranging from -0.50 to 0.06. It cannot be true that in the future, we should expect 95% of the effect sizes to fall between -0.07 to 0.48 **and** 95% of the effect sizes to fall between -0.50 to 0.06. 
 
 
 
@@ -229,8 +229,8 @@ n <- 100
 metadata <- data.frame(yi = numeric(0), vi = numeric(0))
 
 for (i in 1:nSims) { # for each simulated study
-  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce  simulated participants
-  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce  simulated participants
+  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce simulated participants
+  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce simulated participants
   metadata[i,1] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$yi
   metadata[i,2] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$vi
 }
@@ -254,7 +254,7 @@ Keeping the uncertainty of standard deviations in mind can be important. When re
 
 ## Computing Confidence Intervals around Effect Sizes
 
-In 1994, Cohen [-@cohen_earth_1994] reflected on the reason confidence intervals were rarely reported: "I suspect that the main reason they are not reported is that they are so embarrassingly large!" This might be, but another reason might have been that statistical software rarely provided confidence intervals around effect sizes in the time when Cohen wrote his article. It has become increasingly easy to report confidence intervals with the popularity of free software packages in R, even though these packages might not provide solutions for all statistical tests yet. The [Journal Article Reporting Standards](https://apastyle.apa.org/jars/quantitative)  recommend to report "effect-size estimates and confidence intervals on estimates that correspond to each inferential test conducted, when possible".
+In 1994, Cohen [-@cohen_earth_1994] reflected on the reason confidence intervals were rarely reported: "I suspect that the main reason they are not reported is that they are so embarrassingly large!" This might be, but another reason might have been that statistical software rarely provided confidence intervals around effect sizes in the time when Cohen wrote his article. It has become increasingly easy to report confidence intervals with the popularity of free software packages in R, even though these packages might not provide solutions for all statistical tests yet. The [Journal Article Reporting Standards](https://apastyle.apa.org/jars/quantitative) recommend to report "effect-size estimates and confidence intervals on estimates that correspond to each inferential test conducted, when possible".
 
 One easy solution to calculating effect sizes and confidence intervals is [MOTE](https://www.aggieerin.com/shiny-server/) made by Dr. Erin Buchanan and her lab. The website comes with a full collection of tutorials, comparisons with other software packages, and demonstration videos giving accessible overviews of how to compute effect sizes and confidence intervals for a wide range of tests based on summary statistics. This means that whichever software you use to perform statistical tests, you can enter sample sizes and means, standard deviations, or test statistics to compute effect sizes and their confidence intervals. For example, the video below gives an overview of how to compute a confidence interval around Cohen's *d* for an independent *t*-test.
 
@@ -272,7 +272,7 @@ MBESS is another R package that has a range of options to compute effect sizes a
 MBESS::smd(Mean.1 = 1.7, Mean.2 = 2.1, s.1 = 1.01, s.2 = 0.96, n.1 = 77, n.2 = 78)
 ```
 
-If you feel comfortable analyzing your data in R, the `effectsize` package offers a complete set of convenient solutions to compute effect sizes and confidence intervals [@ben-shachar_effectsize_2020].  
+If you feel comfortable analyzing your data in R, the `effectsize` package offers a complete set of convenient solutions to compute effect sizes and confidence intervals [@ben-shachar_effectsize_2020].
 
 ```{r}
 set.seed(33)
@@ -355,8 +355,8 @@ metadata <- data.frame(yi = numeric(0), vi = numeric(0))
 
 for (i in 1:nSims) { # for each simulated study
   n <- sample(30:80, 1)
-  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce  simulated participants
-  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce  simulated participants
+  x <- rnorm(n = n, mean = pop.m1, sd = pop.sd1) # produce simulated participants
+  y <- rnorm(n = n, mean = pop.m2, sd = pop.sd2) # produce simulated participants
   metadata[i,1] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$yi
   metadata[i,2] <- metafor::escalc(n1i = n, n2i = n, m1i = mean(x), m2i = mean(y), sd1i = sd(x), sd2i = sd(y), measure = "SMD")$vi
 }
@@ -457,7 +457,7 @@ ggplot(as.data.frame(x), aes(x)) + # plot data
   theme_bw(base_size = 20) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(),
         panel.grid.minor.x = element_blank()) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   geom_vline(xintercept = mean(x), linetype = "dashed", size = 1) +
   coord_cartesian(xlim = c(50, 150)) +

--- a/08-samplesizejustification.Rmd
+++ b/08-samplesizejustification.Rmd
@@ -528,7 +528,7 @@ curve(eta_pop_dist, 0.00000000001, 1, n = 10000, col = "grey33", lwd = 3, lty = 
 
 ```{r, echo = FALSE}
 # convert eta of 0.176 to f of 0.4621604
-pwr_res <- pwr::pwr.anova.test(k = 3,  
+pwr_res <- pwr::pwr.anova.test(k = 3, 
                f = 0.4621604, 
                sig.level = 0.05, 
                power = 0.8)$n

--- a/11-meta.Rmd
+++ b/11-meta.Rmd
@@ -47,7 +47,7 @@ ggplot(as.data.frame(x), aes(x)) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = seq(50, 150, 10)) +
   annotate("text", x = mean(x), y = 0.02, label = paste("Mean = ", round(mean(x)), "\n", "SD = ", round(sd(x)), sep = ""), size = 8) + 
-  theme(plot.background = element_rect(fill = "#fffafa"))  + 
+  theme(plot.background = element_rect(fill = "#fffafa")) + 
   theme(panel.background = element_rect(fill = "#fffafa"))
 
 
@@ -72,7 +72,7 @@ p1 <- ggplot(as.data.frame(x), aes(x)) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = seq(50, 150, 10)) +
   annotate("text", x = mean(x), y = 0.02, label = paste("Mean = ", round(mean(x)), "\n", "SD = ", round(sd(x)), sep = ""), size = 5) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 
@@ -90,7 +90,7 @@ p2 <- ggplot(as.data.frame(x), aes(x)) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = seq(50, 150, 10)) +
   annotate("text", x = mean(x), y = 0.02, label = paste("Mean = ", round(mean(x)), "\n", "SD = ", round(sd(x)), sep = ""), size = 5) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 
@@ -108,7 +108,7 @@ p3 <- ggplot(as.data.frame(x), aes(x)) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = seq(50, 150, 10)) +
   annotate("text", x = mean(x), y = 0.02, label = paste("Mean = ", round(mean(x)), "\n", "SD = ", round(sd(x)), sep = ""), size = 5) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 
@@ -126,7 +126,7 @@ p4 <- ggplot(as.data.frame(x), aes(x)) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = seq(50, 150, 10)) +
   annotate("text", x = mean(x), y = 0.02, label = paste("Mean = ", round(mean(x)), "\n", "SD = ", round(sd(x)), sep = ""), size = 5) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 
@@ -157,7 +157,7 @@ ggplot(as.data.frame(x), aes(x)) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   geom_vline(xintercept = mean(x), colour = "gray20", linetype = "dashed") +
   coord_cartesian(xlim = c(50, 150)) +
@@ -185,7 +185,7 @@ ggplot(as.data.frame(x), aes(x)) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   geom_vline(xintercept = mean(x), colour = "gray20", linetype = "dashed") +
   coord_cartesian(xlim = c(50, 150)) +
@@ -277,7 +277,7 @@ p1 <- ggplot(dataset, aes(DV, fill = as.factor(IV))) +
   ylab("number of people") +
   ggtitle("Data") +
   theme_bw(base_size = 10) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(), panel.grid.minor.x = element_blank()) +
   geom_vline(xintercept = mean(x), colour = "black", linetype = "dashed", size = 1) +
@@ -305,7 +305,7 @@ p2 <- ggplot(dataset, aes(DV, fill = as.factor(IV))) +
   ylab("number of people") +
   ggtitle("Data") +
   theme_bw(base_size = 10) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(), panel.grid.minor.x = element_blank()) +
   geom_vline(xintercept = mean(x), colour = "black", linetype = "dashed", size = 1) +
@@ -333,7 +333,7 @@ p3 <- ggplot(dataset, aes(DV, fill = as.factor(IV))) +
   ylab("number of people") +
   ggtitle("Data") +
   theme_bw(base_size = 10) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(), panel.grid.minor.x = element_blank()) +
   geom_vline(xintercept = mean(x), colour = "black", linetype = "dashed", size = 1) +
@@ -361,7 +361,7 @@ p4 <- ggplot(dataset, aes(DV, fill = as.factor(IV))) +
   ylab("number of people") +
   ggtitle("Data") +
   theme_bw(base_size = 10) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(), panel.grid.minor.x = element_blank()) +
   geom_vline(xintercept = mean(x), colour = "black", linetype = "dashed", size = 1) +
@@ -416,7 +416,7 @@ ggplot(dataset, aes(DV, fill = as.factor(IV))) +
   ylab("number of people") +
   ggtitle("Data") +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(), panel.grid.minor.x = element_blank()) +
   geom_vline(xintercept = mean(x), colour = "black", linetype = "dashed", size = 1) +
@@ -431,7 +431,7 @@ ggplot(dataset, aes(DV, fill = as.factor(IV))) +
 
 The variation in the estimate of the mean decreases as the sample size increases. The larger the sample size, the more precise the estimate of the mean becomes. The **standard deviation of the sample** ($\sigma_x$) of single IQ scores is 15, irrespective of the sample size, and the larger the sample size, the more accurately we can measure the true standard deviation. But the **standard deviation of the sampling distribution of the sample mean** ($\sigma_{\overline{x}}$) decreases, as the sample size increases, and is referred to as the **standard error (SE)**. The estimated standard deviation of the sample mean, or the standard error, calculated based on the observed standard deviation of the sample ($\sigma_x$) is:
 
-$$SE = \sigma_{\overline{x}} =  \frac{\sigma_x}{\sqrt{n}}$$
+$$SE = \sigma_{\overline{x}} = \frac{\sigma_x}{\sqrt{n}}$$
 Based on this formula, and assuming an observed standard deviation of the sample of 15, the standard error of the mean is `r round(15/sqrt(10), 2)` for a sample size of 10, and `r round(15/sqrt(250), 2)` for a sample size of 250. Because estimates with a lower standard error are more precise, the effect size estimates in a meta-analysis are weighed based on the standard error, with the more precise estimates getting more weight. 
 
 So far we have seen random variation in means, but correlations will show similar variation as a function of the sample size. We will continue with our example of measuring IQ scores, but now we search for fraternal (so not identical) twins, and measure their IQ. Estimates from the literature suggest the true correlation of IQ scores between fraternal twins is around *r* = 0.55. We find 30 fraternal twins, measure their IQ scores, and plot the relation between the IQ of both individuals. In this simulation, we assume all twins have a mean IQ of 100 with a standard deviation of 15. 
@@ -471,7 +471,7 @@ ggplot(dataset, aes(x = x, y = y)) +
   ylab("IQ twin 2") +
   ggtitle(paste("Correlation = ", round(cor(x, y), digits = 2), sep = "")) +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), panel.grid.minor.x = element_blank()) +
   theme(plot.title = element_text(hjust = 0.5))
@@ -511,7 +511,7 @@ ggplot(dataset, aes(x = x, y = y)) +
   ylab("IQ twin 2") +
   ggtitle(paste("Correlation = ", round(cor(x, y), digits = 2), sep = "")) +
   theme_bw(base_size = 20) + 
-  theme(plot.background = element_rect(fill = backgroundcolor))  + 
+  theme(plot.background = element_rect(fill = backgroundcolor)) + 
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), panel.grid.minor.x = element_blank()) +
   theme(plot.title = element_text(hjust = 0.5))
@@ -586,7 +586,7 @@ It is now common to visualize the results of a meta-analysis using a forest plot
 
 (ref:freiman1978lab) First version of a forest plot by Freiman and colleagues, 1978 (image from https://www.jameslindlibrary.org/freiman-ja-chalmers-tc-smith-h-kuebler-rr-1978/).
 
-```{r freiman1978, echo=FALSE, out.width  = '100%', fig.height = 10, fig.cap="(ref:freiman1978lab)"}
+```{r freiman1978, echo=FALSE, out.width = '100%', fig.height = 10, fig.cap="(ref:freiman1978lab)"}
 knitr::include_graphics("images/freiman1978.jpg")
 ```
 
@@ -639,7 +639,7 @@ Let's also look at the statistical results of the meta-analysis, which is a bit 
 result
 ```
 
-We see a test for **heterogeneity**, a topic we will return to [below](#heterogeneity). We see the model results, which in this specific simulation yielded a meta-analytic effect size estimate of `r round(result$b[1], 2)`. The confidence interval around the effect size estimate [`r round(result$ci.lb, 2)` ; `r round(result$ci.ub, 2)`] is much narrower than we saw before for a single study. This is because the 12 studies we simulated together have quite a large sample size, and the larger the sample size, the smaller the standard error, and thus the narrower the confidence interval is. The meta-analytic effect size estimate is statistically different from 0 (*p* \< 0.0001) so we can reject the null hypothesis even if we use a stringent alpha level, such as 0.001. Note that, as discussed in the chapter on sample size justification and in line with the section on justifying error rates in the chapter on error control, it seems sensible to use a much lower alpha level than 5% in meta-analyses. It is possible to set the alpha level in `metafor`, e.g using `level = 0.999` (for an alpha level of 0.001), but this adjusts all confidence intervals, including those of the individual studies, which will mostly have used an alpha level of 0.05, so it is easier to just manually check if the test is significant at your chosen alpha level (e.g., 0.001).
+We see a test for **heterogeneity**, a topic we will return to [below](#heterogeneity). We see the model results, which in this specific simulation yielded a meta-analytic effect size estimate of `r round(result$b[1], 2)`. The confidence interval around the effect size estimate [`r round(result$ci.lb, 2)` ; `r round(result$ci.ub, 2)`] is much narrower than we saw before for a single study. This is because the 12 studies we simulated together have quite a large sample size, and the larger the sample size, the smaller the standard error, and thus the narrower the confidence interval is. The meta-analytic effect size estimate is statistically different from 0 (*p* \< 0.0001) so we can reject the null hypothesis even if we use a stringent alpha level, such as 0.001. Note that, as discussed in the chapter on sample size justification and in line with the section on justifying error rates in the chapter on error control, it seems sensible to use a much lower alpha level than 5% in meta-analyses. It is possible to set the alpha level in `metafor`, e.g. using `level = 0.999` (for an alpha level of 0.001), but this adjusts all confidence intervals, including those of the individual studies, which will mostly have used an alpha level of 0.05, so it is easier to just manually check if the test is significant at your chosen alpha level (e.g., 0.001).
 
 ## Fixed Effect vs Random Effects
 
@@ -693,8 +693,8 @@ di <- numeric(nSims) # set up empty vector for failures Group 2
 
 for (i in 1:nSims) { # for each simulated experiment
   n <- sample(30:80, 1)
-  x <- rbinom(n, 1, pr1) # participants (1 = success, 0 is failure)
-  y <- rbinom(n, 1, pr2) # participants (1 = success, 0 is failure)
+  x <- rbinom(n, 1, pr1) # participants (1 = success, 0 = failure)
+  y <- rbinom(n, 1, pr2) # participants (1 = success, 0 = failure)
   ai[i] <- sum(x == 1) # Successes Group 1
   bi[i] <- sum(x == 0) # Failures Group 1
   ci[i] <- sum(y == 1) # Successes Group 2
@@ -710,13 +710,13 @@ metadata <- escalc(measure = "OR",
 # Perform Meta-analysis
 result <- rma(yi, vi, data = metadata)
 # Create forest plot. Using ilab and ilab.xpos arguments to add counts
-par(mar=c(5,4,0,2))
+par(mar=c(5, 4, 0, 2))
 par(bg = "#fffafa")
 forest(result, 
        ilab = cbind(metadata$ai, metadata$bi, metadata$ci, metadata$di), 
        xlim = c(-10, 8), 
        ilab.xpos = c(-7, -6, -5, -4))
-text(c(-7,-6,-5,-4), 14.7, c("E+", "E-", "C+", "C-"), font = 2, cex = .8)
+text(c(-7, -6, -5, -4), 14.7, c("E+", "E-", "C+", "C-"), font = 2, cex = .8)
 
 ```
 
@@ -756,8 +756,8 @@ di <- numeric(nSims) # set up empty vector for failures Group 2
 
 for (i in 1:nSims/2) { # for half (/2) of the simulated studies
   n <- sample(30:80, 1)
-  x <- rbinom(n, 1, pr1) # produce simulated participants (1 = success, 0 is failure)
-  y <- rbinom(n, 1, pr2) # produce simulated participants (1 = success, 0 is failure)
+  x <- rbinom(n, 1, pr1) # produce simulated participants (1 = success, 0 = failure)
+  y <- rbinom(n, 1, pr2) # produce simulated participants (1 = success, 0 = failure)
   ai[i] <- sum(x == 1) # Successes Group 1
   bi[i] <- sum(x == 0) # Failures Group 1
   ci[i] <- sum(y == 1) # Successes Group 2
@@ -769,8 +769,8 @@ pr2 <- 0.7 # Set percentage of successes in Group 2
 
 for (i in (nSims/2 + 1):(nSims)) { # for the other half (/2) of each simulated study
   n <- sample(30:80, 1)
-  x <- rbinom(n, 1, pr1) # produce simulated participants (1 = success, 0 is failure)
-  y <- rbinom(n, 1, pr2) # produce simulated participants (1 = success, 0 is failure)
+  x <- rbinom(n, 1, pr1) # produce simulated participants (1 = success, 0 = failure)
+  y <- rbinom(n, 1, pr2) # produce simulated participants (1 = success, 0 = failure)
   ai[i] <- sum(x == 1) # Successes Group 1
   bi[i] <- sum(x == 0) # Failures Group 1
   ci[i] <- sum(y == 1) # Successes Group 2
@@ -869,7 +869,7 @@ D) It is generally recommended to compute a **random effects** model, as this re
 
 
 
-(ref:meta-sim-randlab) Simulated studies under a random effects model
+(ref:meta-sim-randlab) Simulated studies under a random effects model.
 
 ```{r meta-sim-rand, echo = FALSE, fig.cap="(ref:meta-sim-randlab)"}
 set.seed(199)
@@ -895,7 +895,7 @@ metafor::forest(result)
 
 
 
-(ref:meta-sim-fixedlab) Simulated studies under a fixed effect model
+(ref:meta-sim-fixedlab) Simulated studies under a fixed effect model.
 
 ```{r meta-sim-fixed, echo = FALSE, fig.cap="(ref:meta-sim-fixedlab)"}
 


### PR DESCRIPTION
It fixes forgotten punctuations, forgotten inline R codes, and extra spacing.
- **11-meta.Rmd**, line 642: changes `e.g` to `e.g.`