### PR TITLE
Fix minor plaintext typos

### DIFF
--- a/06-effectsize.Rmd
+++ b/06-effectsize.Rmd
@@ -97,7 +97,7 @@ $$
 t = \frac{{\overline{M}}_{1}{- \overline{M}}_{2}}{\text{SD}_{\text{pooled}} \times \sqrt{\frac{1}{n_{1}} + \frac{1}{n_{2}}}}
 $$
 
-Here ${\overline{M}}_{1}{- \overline{M}}_{2}$ is the difference between the means, and $\text{SD}_{\text{pooled}}$ is the pooled standard deviation [@lakens_calculating_2013], and n1 and n2 are the sample sizes of the two groups that are being compared. The *t*-value is used to determine whether the difference between two groups in a *t*-test is statistically significant (as explained in the chapter on [*p*-values](#pvalue). The formula for Cohen’s *d*_ is very similar:
+Here ${\overline{M}}_{1}{- \overline{M}}_{2}$ is the difference between the means, and $\text{SD}_{\text{pooled}}$ is the pooled standard deviation [@lakens_calculating_2013], and n1 and n2 are the sample sizes of the two groups that are being compared. The *t*-value is used to determine whether the difference between two groups in a *t*-test is statistically significant (as explained in the chapter on [*p*-values](#pvalue). The formula for Cohen’s *d* is very similar:
 
 $$d_s = \frac{{\overline{M}}_{1}{-\overline{M}}_{2}}{\text{SD}_{\text{pooled}}}$$
 

--- a/07-CI.Rmd
+++ b/07-CI.Rmd
@@ -109,7 +109,7 @@ $$
 \mu \pm t_{df, 1-(\alpha/2)} SE
 $$
 
-With a 95% confidence interval, the $\alpha$ = 0.05, and thus the critical *t*-value for the degrees of freedom for 1- $\alpha$ /2, or the 0.975th quantile is calculated. Remember that a *t*-distribution has slightly thicker tails than a Z-distribution. Where the 0.975th quantile for a Z-distribution is 1.96, the value for a *t*-distribution with for example df = 19 is 2.093. This value is multiplied by the standard error, and added (for the upper limit of the confidence interval) or subtracted (for the lower limit of the confidence interval) from the mean.
+With a 95% confidence interval, the $\alpha$ = 0.05, and thus the critical *t*-value for the degrees of freedom for 1- $\alpha$ /2, or the 0.975th quantile is calculated. Remember that a *t*-distribution has slightly thicker tails than a *Z*-distribution. Where the 0.975th quantile for a *Z*-distribution is 1.96, the value for a *t*-distribution with for example df = 19 is 2.093. This value is multiplied by the standard error, and added (for the upper limit of the confidence interval) or subtracted (for the lower limit of the confidence interval) from the mean.
 
 ## Overlapping Confidence Intervals
 


### PR DESCRIPTION
It fixes one typo, an unnecessary `_` after Cohen's *d*.
It fixes two italicization.