### PR TITLE
Build pdf

### DIFF
--- a/10-sequential.Rmd
+++ b/10-sequential.Rmd
@@ -81,7 +81,7 @@ The analysis can also be performed in the `rpact` [shiny app](https://rpact.shin
 (ref:rpactshinylab) Screenshot of rpact Shiny app.
 
 ```{r rpactshiny, fig.margin=FALSE, echo=FALSE, fig.cap="(ref:rpactshinylab)"}
-knitr::include_graphics("images/RPact1.png")
+knitr::include_graphics("images/rpact1.png")
 ```
 
 ## Comparing Spending Functions

--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -42,8 +42,6 @@
 \usepackage{makeidx}
 \makeindex
 
-\urlstyle{tt}
-
 \usepackage{amsthm}
 \makeatletter
 \def\thm@space@setup{%


### PR DESCRIPTION
Looks like you've already got a working PDF version, but I thought I'd just highlight these two tiny changes that I needed to make to get it working on my system.

I can then run `bookdown::render_book(output_format = 'bookdown::pdf_book')` and get a properly rendered PDF with correct chapters numbering etc.  

This looks like a great resource, thanks for putting in the time to write it!