### PR TITLE
Change repo-branch: `main` to `master` for urls

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,7 +22,7 @@ book:
   #     theme: clean
   #     openSidebar: false
   repo-url: https://github.com/Lakens/statistical_inferences
-  repo-branch: main
+  repo-branch: master
   repo-actions: [edit, issue, source]
   downloads: [pdf, epub]
   sharing: [twitter]


### PR DESCRIPTION
### Problem
The branch name of the repo is `master` but urls are created according to the default branch name `main` as mentioned at <https://github.com/quarto-dev/quarto-cli/discussions/4826>. Because **Edit this page** and **View source** buttons in every page contains branch names in their urls, they do not work now.

---

### Solution
It updates `repo-branch: main` to `repo-branch: master` to solve this.

---

### Example
Example for homepage(<https://lakens.github.io/statistical_inferences/>): old and not working button urls:
- https://github.com/Lakens/statistical_inferences/edit/main/index.qmd
- https://github.com/Lakens/statistical_inferences/blob/main/index.qmd

Example for homepage(<https://lakens.github.io/statistical_inferences/>): new and working button urls:
- https://github.com/Lakens/statistical_inferences/edit/master/index.qmd
- https://github.com/Lakens/statistical_inferences/blob/master/index.qmd