### PR TITLE
Update deprecated functions/arguments for `ggplot()` 3.4.0

### DIFF
--- a/05-questions.qmd
+++ b/05-questions.qmd
@@ -232,7 +232,7 @@ df_1_vs_2 <- data.frame(
 )
 
 ggplot(df_1_vs_2, aes(x = effect_size, y = ratio, color = power)) +
-  geom_line(size = 1.5) +
+  geom_line(linewidth = 1.5) +
   labs(x = "Effect size (d)", y = "Ratio One-sided/Two-sided Sample Size") +
   theme(
     legend.position = "bottom", legend.direction = "horizontal",

--- a/06-effectsize.qmd
+++ b/06-effectsize.qmd
@@ -242,13 +242,13 @@ Now we have the basis to look at interaction effects. Different patterns of mean
 #| fig-cap: "Schematic illustration of a disordinal (or cross-over) and ordinal interaction."
 
 df <- data.frame(
-    A = factor(c("A1","A1","A2","A2")),
-    B = factor(c("B1","B2","B1","B2")),
+    A = factor(c("A1", "A1", "A2", "A2")),
+    B = factor(c("B1", "B2", "B1", "B2")),
     Y = c(1, 0.0, 0.1, 1)
 )
 
-p1 <- ggplot(data=df, aes(x=A, y=Y, group=B, shape=B)) +
-    geom_line(size = 2) +
+p1 <- ggplot(data = df, aes(x = A, y = Y, group = B, shape = B)) +
+    geom_line(linewidth = 2) +
     geom_point(size = 4, fill = "white") +
   scale_shape_manual(values = c(22, 21)) +
   ggtitle("disordinal interaction") +
@@ -257,13 +257,13 @@ p1 <- ggplot(data=df, aes(x=A, y=Y, group=B, shape=B)) +
   theme(panel.background = element_rect(fill = backgroundcolor))
 
 df <- data.frame(
-    A = factor(c("A1","A1","A2","A2")),
-    B = factor(c("B1","B2","B1","B2")),
+    A = factor(c("A1", "A1", "A2", "A2")),
+    B = factor(c("B1", "B2", "B1", "B2")),
     Y = c(1, 0, 0.1, 0)
 )
 
-p2 <- ggplot(data=df, aes(x=A, y=Y, group=B, shape=B)) +
-    geom_line(size = 2) +
+p2 <- ggplot(data = df, aes(x = A, y = Y, group = B, shape = B)) +
+    geom_line(linewidth = 2) +
     geom_point(size = 4, fill = "white") +
   scale_shape_manual(values = c(22, 21)) +
   ggtitle("ordinal interaction") +

--- a/07-CI.qmd
+++ b/07-CI.qmd
@@ -175,7 +175,7 @@ ggplot(as.data.frame(x), aes(x)) + # plot data
             fill = "gold") + # draw yellow PI area
   geom_rect(aes(xmin = cil, xmax = ciu, ymin = 0, ymax = Inf),
             fill = "#E69F00") + # draw orange CI area
-  geom_histogram(colour = "black", fill = "grey", aes(y = ..density..),
+  geom_histogram(colour = "black", fill = "grey", aes(y = after_stat(density)),
                  bins = 20) + xlab("Score") + ylab("frequency") +
   theme_bw(base_size = 20) + 
   theme(plot.background = element_rect(fill = backgroundcolor)) + 

--- a/07-CI.qmd
+++ b/07-CI.qmd
@@ -182,7 +182,7 @@ ggplot(as.data.frame(x), aes(x)) + # plot data
   theme(panel.background = element_rect(fill = backgroundcolor)) +
   theme(panel.grid.major.x = element_blank(), axis.text.y = element_blank(),
         panel.grid.minor.x = element_blank()) +
-  geom_vline(xintercept = mean(x), linetype = "dashed", size = 1) +
+  geom_vline(xintercept = mean(x), linetype = "dashed", linewidth = 1) +
   coord_cartesian(xlim = c(50, 150)) +
   scale_x_continuous(breaks = c(seq(50, 150, 10))) +
   annotate("text", x = mean(x), y = 0.02, label = paste(

--- a/11-meta.qmd
+++ b/11-meta.qmd
@@ -35,7 +35,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # simulate data
 
 # plot data adding normal distribution and annotations
 ggplot(as.data.frame(x), aes(x)) +
-  geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
+  geom_histogram(colour = "black", fill = "grey", aes(y = after_stat(density)), binwidth = 2) +
   stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +

--- a/11-meta.qmd
+++ b/11-meta.qmd
@@ -36,7 +36,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # simulate data
 # plot data adding normal distribution and annotations
 ggplot(as.data.frame(x), aes(x)) +
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
-  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), size = 1, color = "red", lty = 2) +
+  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 20) +
@@ -61,7 +61,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # create sample from normal distribution
 # plot data adding normal distribution and annotations
 p1 <- ggplot(as.data.frame(x), aes(x)) +
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
-  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), size = 1, color = "red", lty = 2) +
+  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 12) +
@@ -79,7 +79,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # create sample from normal distribution
 # plot data adding normal distribution and annotations
 p2 <- ggplot(as.data.frame(x), aes(x)) +
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
-  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), size = 1, color = "red", lty = 2) +
+  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 12) +
@@ -97,7 +97,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # create sample from normal distribution
 # plot data adding normal distribution and annotations
 p3 <- ggplot(as.data.frame(x), aes(x)) +
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
-  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), size = 1, color = "red", lty = 2) +
+  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 12) +
@@ -115,7 +115,7 @@ x <- rnorm(n = n, mean = 100, sd = 15) # create sample from normal distribution
 # plot data adding normal distribution and annotations
 p4 <- ggplot(as.data.frame(x), aes(x)) +
   geom_histogram(colour = "black", fill = "grey", aes(y = ..density..), binwidth = 2) +
-  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), size = 1, color = "red", lty = 2) +
+  stat_function(fun = dnorm, args = c(mean = 100, sd = 15), linewidth = 1, color = "red", lty = 2) +
   xlab("IQ") +
   ylab("number of people") +
   theme_bw(base_size = 12) +

--- a/15-researchintegrity.qmd
+++ b/15-researchintegrity.qmd
@@ -80,10 +80,10 @@ ggplot(long, aes(x = variable, y = value, fill = variable)) +
  theme(plot.margin = margin(0, 0, 0, 0, "cm"), plot.background = element_rect(fill = backgroundcolor), panel.background = element_rect(fill = backgroundcolor), legend.background = element_rect(fill= backgroundcolor), legend.direction = "horizontal", legend.position = "bottom", axis.title = element_text(size = 13), axis.text.x = element_text(size = 10), axis.text.y = element_text(size = 20), panel.grid.major.x = element_line(linewidth = .1, color = "black"), axis.ticks.x = element_blank()) +
   ggtitle("Self-admittance rates of engaging in QRP's at least once") +
   scale_fill_manual(values = c("#000000", "#88CCEE", "#CC6677", "#DDCC77", "#117733", "#332288", "#AA4499", "#E69F00", "#44AA99", "#999933", "#882255", "#661100", "#6699CC", "#888888", "#ffffff"),
-                    labels = c("John 2012", "Agnoli 2017",  "Motyl  2017", "Rabelo 2020", "Fraser 2018 (eco)", "Fraser 2018 (evo)", "Makel 2021", "Bakker 2021", "Chin 2021", "Fiedler 2016", "Moran 2022", "Swift 2022 (faculty)", "Latan 2021", "Garcia-Garzon 2022", "Brachem 2022"), name = "Study") +
+                    labels = c("John 2012", "Agnoli 2017", "Motyl  2017", "Rabelo 2020", "Fraser 2018 (eco)", "Fraser 2018 (evo)", "Makel 2021", "Bakker 2021", "Chin 2021", "Fiedler 2016", "Moran 2022", "Swift 2022 (faculty)", "Latan 2021", "Garcia-Garzon 2022", "Brachem 2022"), name = "Study") +
   ylab("Percentage") + xlab("QRP's") +
   scale_y_continuous(limits = c(0, 70), breaks = seq(0, 70, 10)) + 
-  facet_wrap(~labels, scales = "free_x", switch = "y", nrow = 4) +
+  facet_wrap(~labels, scales = "free_x", strip.position = "left", nrow = 4) +
   theme(axis.text.y = element_blank(), axis.ticks.y = element_blank(), strip.background = element_blank(), strip.text.y = element_text(size = 12))
 
 

--- a/15-researchintegrity.qmd
+++ b/15-researchintegrity.qmd
@@ -66,7 +66,7 @@ long = subset(long, !is.na(value))
 # ggplot(long, aes(x = labels, y = value, fill = variable)) +
 #   geom_bar(stat = "identity", colour = "black", width = 0.8, position = position_dodge2(.8, preserve = "total")) +
 #   coord_flip() +
-#   theme(plot.margin = margin(0, 0, 3, 0, "cm"), plot.background = element_rect(fill = backgroundcolor), panel.background = element_rect(fill = backgroundcolor), legend.background = element_rect(fill= backgroundcolor), legend.position = c(0.3,-0.10),  legend.direction = "horizontal", legend.margin = margin(0), axis.text.y = element_text(size = 13), panel.grid.major.x = element_line( size=.1, color="black" ), axis.ticks.x = element_blank()) +
+#   theme(plot.margin = margin(0, 0, 3, 0, "cm"), plot.background = element_rect(fill = backgroundcolor), panel.background = element_rect(fill = backgroundcolor), legend.background = element_rect(fill= backgroundcolor), legend.position = c(0.3,-0.10),  legend.direction = "horizontal", legend.margin = margin(0), axis.text.y = element_text(size = 13), panel.grid.major.x = element_line(linewidth=.1, color="black"), axis.ticks.x = element_blank()) +
 #   ggtitle("Self-admittance rates of engaging in QRP's at least once") +
 #   scale_fill_manual(values = c("#000000", "#004949", "#009292", "#ff6db6", "#ffb6db", "#490092", "#006edb", "#b66dff", "#6db6ff", "#b6dbff", "#920000", "#924900", "#db6d00", "#24ff24", "#ffff6d", "#ffffff"),
 #                     labels = c("John 2012", "Agnoli 2017", "Motyl  2017", "Rabelo 2020", "Fraser 2018 (eco)", "Fraser 2018 (evo)", "Makel 2021", "Bakker 2021", "Chin 2021", "Fiedler 2016", "Moran 2022", "Swift 2022 (faculty)", "Latan 2021", "Garcia-Garzon 2022", "Brachem 2022"), name = "Study") +
@@ -77,7 +77,7 @@ long = subset(long, !is.na(value))
 ggplot(long, aes(x = variable, y = value, fill = variable)) +
   coord_flip() +
   geom_bar(stat = "identity", colour = "black", width = 0.8, position = position_dodge(.8, preserve = "single")) +
- theme(plot.margin = margin(0, 0, 0, 0, "cm"), plot.background = element_rect(fill = backgroundcolor), panel.background = element_rect(fill = backgroundcolor), legend.background = element_rect(fill= backgroundcolor), legend.direction = "horizontal", legend.position = "bottom", axis.title = element_text(size = 13), axis.text.x = element_text(size = 10), axis.text.y = element_text(size = 20), panel.grid.major.x = element_line(size = .1, color = "black"), axis.ticks.x = element_blank()) +
+ theme(plot.margin = margin(0, 0, 0, 0, "cm"), plot.background = element_rect(fill = backgroundcolor), panel.background = element_rect(fill = backgroundcolor), legend.background = element_rect(fill= backgroundcolor), legend.direction = "horizontal", legend.position = "bottom", axis.title = element_text(size = 13), axis.text.x = element_text(size = 10), axis.text.y = element_text(size = 20), panel.grid.major.x = element_line(linewidth = .1, color = "black"), axis.ticks.x = element_blank()) +
   ggtitle("Self-admittance rates of engaging in QRP's at least once") +
   scale_fill_manual(values = c("#000000", "#88CCEE", "#CC6677", "#DDCC77", "#117733", "#332288", "#AA4499", "#E69F00", "#44AA99", "#999933", "#882255", "#661100", "#6699CC", "#888888", "#ffffff"),
                     labels = c("John 2012", "Agnoli 2017",  "Motyl  2017", "Rabelo 2020", "Fraser 2018 (eco)", "Fraser 2018 (evo)", "Makel 2021", "Bakker 2021", "Chin 2021", "Fiedler 2016", "Moran 2022", "Swift 2022 (faculty)", "Latan 2021", "Garcia-Garzon 2022", "Brachem 2022"), name = "Study") +


### PR DESCRIPTION
### Problem

Now, above the figure <https://lakens.github.io/statistical_inferences/05-questions.html#fig-onesidedtwosidedratio> there is a warning:

![f5 5](https://user-images.githubusercontent.com/40212849/236449085-c5512850-c1d9-4b13-8d04-b952effd7bcf.png)

---

### Solution

- This pull request updates the argument `size` to `linewidth` in line-based `ggplot()`objects for 3.4.0 update as mentioned at <https://www.tidyverse.org/blog/2022/11/ggplot2-3-4-0/#hello-linewidth>.
- The rest of the changes are spacing for easier readability.
