### PR TITLE
Fix broken DOI link for Kelley & Rausch, 2006

### DIFF
--- a/include/book.bib
+++ b/include/book.bib
@@ -3521,7 +3521,7 @@ Subject\_term\_id: human-behaviour;policy;research-management;science-technology
   volume = {11},
   number = {4},
   pages = {363--385},
-  doi = {10.1037},
+  doi = {10.1037/1082-989X.11.4.363},
   urldate = {2016-07-27},
   annotation = {00083}
 }


### PR DESCRIPTION
the current DOI link for this reference leads to a 404 page:

> Kelley, K., & Rausch, J. R. (2006). Sample size planning for the standardized mean difference: Accuracy in parameter estimation via narrow confidence intervals. Psychological Methods, 11(4), 363–385. https://doi.org/10.1037

Seems like the correct DOI (`10.1037/1082-989X.11.4.363`) was cut off accidentally.